### PR TITLE
remove whitespace in npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Startup Watch",
+  "name": "StartupWatch",
   "version": "0.1.0",
   "description": "An Ionic project",
   "dependencies": {


### PR DESCRIPTION
Whitespace is not permitted in a package name in newer versions of npm. Wasn't able to `npm install` after clone. Got error: 'Error: Invalid name: "Startup Watch"'. 

https://github.com/npm/npm/issues/3159
